### PR TITLE
Inspect Trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 
 name = "inspect"
 version = "0.1.2"
-authors = ["reem"]
+authors = ["reem", "Nathan Lilienthal <nathan@nixpulvis.com>"]
 description = "Advanced logging for dumping expressions during debugging."
 repository = "https://github.com/reem/rust-inspect"
 license = "MIT"
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ fn main() {
     let a = 7u32;
     let b = 4u64;
     inspect!(a, b, a as u64 + b);
-    // examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
+    //=> examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ fn main() {
     let b = 4u64;
     inspect!(a, b, a as u64 + b);
     //=> examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
+    inspect::p(false);
+    //=> [bool] false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Inspect [![Build Status](https://secure.travis-ci.org/reem/rust-inspect.png?branch=master)](https://travis-ci.org/reem/rust-inspect)
 
-A lightweight library providing a very useful `inspect!` macro that
-logs meta information like the filename and line number in addition
-to the expressions you debug and their results.
+A library designed to for inspecting values, and meta information like the
+filename, and line number, and expression. Inspection of a value also includes
+reflecting on it's type.
+
+These functions and macros are intended for use while developing, and are not
+advised to be used in releases.
 
 ## Example
 
 ```rust
-#![feature(phase)]
-
-extern crate debug;
-#[phase(plugin, link)]
+#[macro_use(inspect)]
 extern crate inspect;
 
 fn main() {
-    let a = 7u;
-    let b = 4u;
-    inspect!(a, b, a + b);
-    // => file.rs - 10: a = 7, b = 4, a + b = 11
+    let a = 7u32;
+    let b = 4u64;
+    inspect!(a, b, a as u64 + b);
+    // examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
 }
 ```
 
@@ -26,9 +26,8 @@ fn main() {
 Add:
 
 ```toml
-[dependencies.inspect]
-
-git = "https://github.com/reem/rust-inspect"
+[dependencies]
+inspect = "*"
 ```
 
 to your `Cargo.toml`.
@@ -36,4 +35,3 @@ to your `Cargo.toml`.
 ## License
 
 MIT
-

--- a/examples/inspect.rs
+++ b/examples/inspect.rs
@@ -4,6 +4,4 @@ extern crate inspect;
 fn main() {
     let a = 7;
     inspect!(a, a + 4, a - 3);
-    // Logs: "basic.rs - 6: a = 7, a + 4 = 11, a - 3 = 4"
 }
-

--- a/examples/p.rs
+++ b/examples/p.rs
@@ -1,0 +1,5 @@
+extern crate inspect;
+
+fn main() {
+    inspect::p(12);
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,9 @@
+#[macro_use(inspect)]
+extern crate inspect;
+
+fn main() {
+    let a = 7u32;
+    let b = 4u64;
+    inspect!(a, b, a as u64 + b);
+    // examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -5,5 +5,7 @@ fn main() {
     let a = 7u32;
     let b = 4u64;
     inspect!(a, b, a as u64 + b);
-    // examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
+    //=> examples/readme.rs - 7: a = [u32] 7, b = [u64] 4, a as u64 + b = [u64] 11,
+    inspect::p(false);
+    //=> [bool] false
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
+#![feature(core_intrinsics)]
 #![deny(missing_docs)]
 
 //! A lightweight library for quickly debugging rust code.
+
+use std::fmt::Debug;
 
 /// Logs the file, line number, and expressions along with their `Show` value.
 ///
@@ -22,8 +25,42 @@ macro_rules! inspect(
             "{} - {}: {}",
             file!(), line!(),
             format!(
-                concat!($(stringify!($a), " = {}, "),*), $($a),*
+                concat!($(stringify!($a), " = {}, "),*), $(::inspect::Inspect::inspect(&$a)),*
             )
         );
     }
 );
+
+/// Helpful function for printing a value's inspect string.
+///
+/// # Examples
+///
+/// ```
+/// use inspect::{p, Inspect};
+///
+/// p(43);  // stdout=> [i32] 43
+/// ```
+pub fn p<T: Inspect>(value: T) {
+    println!("{}", value.inspect());
+}
+
+/// Inspect trait for reflecting on values.
+pub trait Inspect {
+    /// Returns a string describing a value and it's type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inspect::Inspect;
+    ///
+    /// assert_eq!(7.inspect(), "[i32] 7");
+    /// ```
+    fn inspect(&self) -> String;
+}
+
+impl<T: Debug> Inspect for T {
+    fn inspect(&self) -> String {
+        let type_name = unsafe { std::intrinsics::type_name::<T>() };
+        format!("[{}] {:?}", type_name, self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 /// # #[macro_use(inspect)]
 /// # extern crate inspect;
 /// fn main() {
-///     let a = 7u;
+///     let a = 7;
 ///     inspect!(a, a + 4); //=> file.rs - X: a = 7, a + 4 = 11
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
 
 use std::fmt::Debug;
 
-/// Logs the file, line number, and expressions along with their `Show` value.
+/// Logs the file, line number, and expressions along with their `inspect` value.
+/// All arguments of this macro must have trait `Inspect`.
 ///
 /// # Examples
 ///
@@ -14,7 +15,8 @@ use std::fmt::Debug;
 /// # extern crate inspect;
 /// fn main() {
 ///     let a = 7;
-///     inspect!(a, a + 4); //=> file.rs - X: a = 7, a + 4 = 11
+///     inspect!(a, a + 4);
+///     //=> <file>.rs - 9: a = [i32] 7, a + 4 = [i32] 11,
 /// }
 /// ```
 ///
@@ -58,6 +60,8 @@ pub trait Inspect {
     fn inspect(&self) -> String;
 }
 
+
+/// asd
 impl<T: Debug> Inspect for T {
     fn inspect(&self) -> String {
         let type_name = unsafe { std::intrinsics::type_name::<T>() };


### PR DESCRIPTION
I find myself wanting to know the types of things very often. While learning and playing and debugging knowing the types of _everything_ is critical. Currently I either reason about what type I think something is (time consuming) or I use the compiler to tell me `something.asdas` (slow).

This implements an `Inspect` trait for getting a nice formatted `Debug` string with the corresponding type. For example `3u32`'s inspect string is `[u32] 3`.

Lastly in addition to the `inspect!` macro, I've added a function `p` which `println!`s it's argument. This is akin to how Ruby works, and will make quickly asking for the types of many values easy.
## Examples

Here are three main uses, for `inspect!`, `inspect::p`, and `Inspect::inspect`.

``` rust
#[macro_use(inspect)]
extern crate inspect;

use inspect::Inspect;

fn main() {
    let v = vec!(12, 41);
    inspect!(v);
    //=> src/main.rs - 8: v = [collections::vec::Vec<i32>] [12, 41], 
    inspect::p(&v);
    //=> [&'static collections::vec::Vec<i32>] [12, 41]
    println!("{:?}", v.iter().map(|n| n.inspect()).collect::<Vec<String>>());
    //=> ["[i32] 12", "[i32] 41"]
}
```
